### PR TITLE
Activate link regeneration

### DIFF
--- a/src/routes/accounts.py
+++ b/src/routes/accounts.py
@@ -1,4 +1,3 @@
-from types import NoneType
 from typing import cast
 from datetime import datetime, timezone
 
@@ -39,7 +38,6 @@ from schemas import (
 )
 from schemas.accounts import (
     GenerateActivationLinkRequestSchema,
-    GenerateActivationLinkResponseSchema,
 )
 from security.interfaces import JWTAuthManagerInterface
 
@@ -267,6 +265,28 @@ async def regenerate_activation_link(
         get_accounts_email_notificator
     ),
 ) -> MessageResponseSchema:
+    """
+    Regenerate an activation link for a user account.
+
+    This endpoint allows users to request a new activation link if their previous
+    one has expired or was lost. It handles the following scenarios:
+    - User not found: Returns 404
+    - User already active: Returns 400
+    - User has valid activation token: Returns 409
+    - User has expired token: Deletes old token and creates new one
+    - User has no token: Creates new activation token
+
+    Args:
+        regenerate_data: Contains the user's email address
+        db: Database session
+        email_sender: Email notification service
+
+    Returns:
+        MessageResponseSchema: Generic success message to prevent information leakage
+
+    Raises:
+        HTTPException: Various status codes based on user state
+    """
     try:
         user = await db.scalar(
             select(UserModel)

--- a/src/routes/accounts.py
+++ b/src/routes/accounts.py
@@ -1,3 +1,4 @@
+from types import NoneType
 from typing import cast
 from datetime import datetime, timezone
 
@@ -35,6 +36,10 @@ from schemas import (
     UserLoginRequestSchema,
     TokenRefreshRequestSchema,
     TokenRefreshResponseSchema,
+)
+from schemas.accounts import (
+    GenerateActivationLinkRequestSchema,
+    GenerateActivationLinkResponseSchema,
 )
 from security.interfaces import JWTAuthManagerInterface
 
@@ -254,6 +259,76 @@ async def activate_account(
     )
 
 
+@router.post("/regenerate-activation-link/")
+async def regenerate_activation_link(
+    regenerate_data: GenerateActivationLinkRequestSchema,
+    db: AsyncSession = Depends(get_db),
+    email_sender: EmailSenderInterface = Depends(
+        get_accounts_email_notificator
+    ),
+) -> MessageResponseSchema:
+    try:
+        user = await db.scalar(
+            select(UserModel)
+            .where(UserModel.email == regenerate_data.email)
+            .options(joinedload(UserModel.activation_token))
+        )
+
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="User with such email is not registered.",
+            )
+
+        if user.is_active:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="User already active.",
+            )
+
+        if user.activation_token:
+            expires_at = user.activation_token.expires_at
+            if (
+                expires_at.tzinfo is None
+                or expires_at.tzinfo.utcoffset(expires_at) is None
+            ):
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if expires_at > datetime.now(timezone.utc):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="User already have an activation link.",
+                )
+            else:
+                await db.execute(
+                    delete(ActivationTokenModel).where(
+                        ActivationTokenModel.id == user.activation_token.id
+                    )
+                )
+                await db.flush()
+
+        activation_token = ActivationTokenModel(user_id=user.id)
+        db.add(activation_token)
+
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="An error occurred during token generation.",
+        ) from e
+    else:
+        activation_link = "http://127.0.0.1/accounts/activate/"
+
+        await email_sender.send_activation_email(user.email, activation_link)
+
+        return MessageResponseSchema(
+            message=(
+                "If you are registered, "
+                "you will receive an email with activation link."
+            )
+        )
+
+
 @router.post(
     "/password-reset/request/",
     response_model=MessageResponseSchema,
@@ -284,6 +359,12 @@ async def request_password_reset_token(
 
     Returns:
         MessageResponseSchema: A success message indicating that instructions will be sent.
+
+    Raises:
+        HTTPException:
+            - 400 Bad Request if the email is not valid.
+            - 404 Not Found if the user does not exist.
+            - 500 Internal Server Error if an error occurs during token generation.
     """
     stmt = select(UserModel).filter_by(email=data.email)
     result = await db.execute(stmt)

--- a/src/schemas/accounts.py
+++ b/src/schemas/accounts.py
@@ -32,10 +32,6 @@ class GenerateActivationLinkRequestSchema(BaseModel):
     email: EmailStr
 
 
-class GenerateActivationLinkResponseSchema(BaseModel):
-    message: str
-
-
 class PasswordResetCompleteRequestSchema(BaseEmailPasswordSchema):
     token: str
 

--- a/src/schemas/accounts.py
+++ b/src/schemas/accounts.py
@@ -7,9 +7,7 @@ class BaseEmailPasswordSchema(BaseModel):
     email: EmailStr
     password: str
 
-    model_config = {
-        "from_attributes": True
-    }
+    model_config = {"from_attributes": True}
 
     @field_validator("email")
     @classmethod
@@ -30,6 +28,14 @@ class PasswordResetRequestSchema(BaseModel):
     email: EmailStr
 
 
+class GenerateActivationLinkRequestSchema(BaseModel):
+    email: EmailStr
+
+
+class GenerateActivationLinkResponseSchema(BaseModel):
+    message: str
+
+
 class PasswordResetCompleteRequestSchema(BaseEmailPasswordSchema):
     token: str
 
@@ -48,9 +54,7 @@ class UserRegistrationResponseSchema(BaseModel):
     id: int
     email: EmailStr
 
-    model_config = {
-        "from_attributes": True
-    }
+    model_config = {"from_attributes": True}
 
 
 class UserActivationRequestSchema(BaseModel):

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -201,16 +201,17 @@ async def seed_user_groups(db_session: AsyncSession):
 @pytest_asyncio.fixture(scope="function")
 async def seed_user(db_session: AsyncSession):
     """
-    Asynchronously seed the User.
+    Asynchronously seed a test user in the database.
 
-    This fixture created dummy user
+    This fixture creates a dummy user with predefined credentials for testing purposes.
+    Note: This fixture should be called after seed_user_groups to ensure user groups exist.
     """
     user_group = await db_session.scalar(
         select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
     )
 
     if user_group is None:
-        raise ValueError("seed_user should be called after seed_groups")
+        raise ValueError("seed_user should be called after seed_user_groups")
 
     user = UserModel.create(
         email=str("dummy@email.com"),

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,15 +1,20 @@
 import pytest_asyncio
 from httpx import AsyncClient, ASGITransport
-from sqlalchemy import insert
+from sqlalchemy import insert, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from config import get_settings, get_accounts_email_notificator, get_s3_storage_client
+from config import (
+    get_settings,
+    get_accounts_email_notificator,
+    get_s3_storage_client,
+)
 from database import (
     reset_database,
     get_db_contextmanager,
     UserGroupEnum,
-    UserGroupModel
+    UserGroupModel,
 )
+from database.models.accounts import UserModel
 from database.populate import CSVDatabaseSeeder
 from main import app
 from security.interfaces import JWTAuthManagerInterface
@@ -20,15 +25,11 @@ from tests.doubles.stubs.emails import StubEmailSender
 
 
 def pytest_configure(config):
-    config.addinivalue_line(
-        "markers", "e2e: End-to-end tests"
-    )
+    config.addinivalue_line("markers", "e2e: End-to-end tests")
     config.addinivalue_line(
         "markers", "order: Specify the order of test execution"
     )
-    config.addinivalue_line(
-        "markers", "unit: Unit tests"
-    )
+    config.addinivalue_line("markers", "unit: Unit tests")
 
 
 @pytest_asyncio.fixture(scope="function", autouse=True)
@@ -99,7 +100,7 @@ async def s3_client(settings):
         endpoint_url=settings.S3_STORAGE_ENDPOINT,
         access_key=settings.S3_STORAGE_ACCESS_KEY,
         secret_key=settings.S3_STORAGE_SECRET_KEY,
-        bucket_name=settings.S3_BUCKET_NAME
+        bucket_name=settings.S3_BUCKET_NAME,
     )
 
 
@@ -110,10 +111,14 @@ async def client(email_sender_stub, s3_storage_fake):
 
     Overrides the dependencies for email sender and S3 storage with test doubles.
     """
-    app.dependency_overrides[get_accounts_email_notificator] = lambda: email_sender_stub
+    app.dependency_overrides[get_accounts_email_notificator] = (
+        lambda: email_sender_stub
+    )
     app.dependency_overrides[get_s3_storage_client] = lambda: s3_storage_fake
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as async_client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as async_client:
         yield async_client
 
     app.dependency_overrides.clear()
@@ -126,7 +131,9 @@ async def e2e_client():
 
     This client is available at the session scope.
     """
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as async_client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as async_client:
         yield async_client
 
 
@@ -173,7 +180,7 @@ async def jwt_manager() -> JWTAuthManagerInterface:
     return JWTAuthManager(
         secret_key_access=settings.SECRET_KEY_ACCESS,
         secret_key_refresh=settings.SECRET_KEY_REFRESH,
-        algorithm=settings.JWT_SIGNING_ALGORITHM
+        algorithm=settings.JWT_SIGNING_ALGORITHM,
     )
 
 
@@ -192,6 +199,31 @@ async def seed_user_groups(db_session: AsyncSession):
 
 
 @pytest_asyncio.fixture(scope="function")
+async def seed_user(db_session: AsyncSession):
+    """
+    Asynchronously seed the User.
+
+    This fixture created dummy user
+    """
+    user = UserModel.create(
+        email=str("dummy@email.com"),
+        raw_password="StrongP@ssword1",
+        group_id=(
+            await db_session.scalar(
+                select(UserGroupModel).where(
+                    UserGroupModel.name == UserGroupEnum.USER
+                )
+            )
+        ).id,
+    )
+
+    db_session.add(user)
+    await db_session.commit()
+    await db_session.refresh(user)
+    yield user
+
+
+@pytest_asyncio.fixture(scope="function")
 async def seed_database(db_session):
     """
     Seed the database with test data if it is empty.
@@ -203,7 +235,9 @@ async def seed_database(db_session):
     :type db_session: AsyncSession
     """
     settings = get_settings()
-    seeder = CSVDatabaseSeeder(csv_file_path=settings.PATH_TO_MOVIES_CSV, db_session=db_session)
+    seeder = CSVDatabaseSeeder(
+        csv_file_path=settings.PATH_TO_MOVIES_CSV, db_session=db_session
+    )
 
     if not await seeder.is_db_populated():
         await seeder.seed()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -205,16 +205,17 @@ async def seed_user(db_session: AsyncSession):
 
     This fixture created dummy user
     """
+    user_group = await db_session.scalar(
+        select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    )
+
+    if user_group is None:
+        raise ValueError("seed_user should be called after seed_groups")
+
     user = UserModel.create(
         email=str("dummy@email.com"),
         raw_password="StrongP@ssword1",
-        group_id=(
-            await db_session.scalar(
-                select(UserGroupModel).where(
-                    UserGroupModel.name == UserGroupEnum.USER
-                )
-            )
-        ).id,
+        group_id=user_group.id,
     )
 
     db_session.add(user)

--- a/src/tests/test_integration/test_accounts.py
+++ b/src/tests/test_integration/test_accounts.py
@@ -12,7 +12,7 @@ from database import (
     PasswordResetTokenModel,
     UserGroupModel,
     UserGroupEnum,
-    RefreshTokenModel
+    RefreshTokenModel,
 )
 
 
@@ -25,44 +25,69 @@ async def test_register_user_success(client, db_session, seed_user_groups):
     """
     payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
     response = await client.post("/api/v1/accounts/register/", json=payload)
     assert response.status_code == 201, "Expected status code 201 Created."
     response_data = response.json()
-    assert response_data["email"] == payload["email"], "Returned email does not match."
+    assert (
+        response_data["email"] == payload["email"]
+    ), "Returned email does not match."
     assert "id" in response_data, "Response does not contain user ID."
 
     stmt_user = select(UserModel).where(UserModel.email == payload["email"])
     result = await db_session.execute(stmt_user)
     created_user = result.scalars().first()
     assert created_user is not None, "User was not created in the database."
-    assert created_user.email == payload["email"], "Created user's email does not match."
+    assert (
+        created_user.email == payload["email"]
+    ), "Created user's email does not match."
 
-    stmt_token = select(ActivationTokenModel).where(ActivationTokenModel.user_id == created_user.id)
+    stmt_token = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == created_user.id
+    )
     result = await db_session.execute(stmt_token)
     activation_token = result.scalars().first()
-    assert activation_token is not None, "Activation token was not created in the database."
-    assert activation_token.user_id == created_user.id, "Activation token's user_id does not match."
-    assert activation_token.token is not None, "Activation token has no token value."
+    assert (
+        activation_token is not None
+    ), "Activation token was not created in the database."
+    assert (
+        activation_token.user_id == created_user.id
+    ), "Activation token's user_id does not match."
+    assert (
+        activation_token.token is not None
+    ), "Activation token has no token value."
 
     expires_at = activation_token.expires_at
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
 
-    assert expires_at > datetime.now(timezone.utc), "Activation token is already expired."
+    assert expires_at > datetime.now(
+        timezone.utc
+    ), "Activation token is already expired."
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_password, expected_error", [
-    ("short", "Password must contain at least 8 characters."),
-    ("NoDigitHere!", "Password must contain at least one digit."),
-    ("nodigitnorupper@", "Password must contain at least one uppercase letter."),
-    ("NOLOWERCASE1@", "Password must contain at least one lower letter."),
-    ("NoSpecial123", "Password must contain at least one special character: @, $, !, %, *, ?, #, &."),
-])
-async def test_register_user_password_validation(client, seed_user_groups, invalid_password, expected_error):
+@pytest.mark.parametrize(
+    "invalid_password, expected_error",
+    [
+        ("short", "Password must contain at least 8 characters."),
+        ("NoDigitHere!", "Password must contain at least one digit."),
+        (
+            "nodigitnorupper@",
+            "Password must contain at least one uppercase letter.",
+        ),
+        ("NOLOWERCASE1@", "Password must contain at least one lower letter."),
+        (
+            "NoSpecial123",
+            "Password must contain at least one special character: @, $, !, %, *, ?, #, &.",
+        ),
+    ],
+)
+async def test_register_user_password_validation(
+    client, seed_user_groups, invalid_password, expected_error
+):
     """
     Test password strength validation in the user registration endpoint.
 
@@ -75,16 +100,17 @@ async def test_register_user_password_validation(client, seed_user_groups, inval
         invalid_password (str): The password to test.
         expected_error (str): The expected error message substring.
     """
-    payload = {
-        "email": "testuser@example.com",
-        "password": invalid_password
-    }
+    payload = {"email": "testuser@example.com", "password": invalid_password}
 
     response = await client.post("/api/v1/accounts/register/", json=payload)
-    assert response.status_code == 422, "Expected status code 422 for invalid input."
+    assert (
+        response.status_code == 422
+    ), "Expected status code 422 for invalid input."
 
     response_data = response.json()
-    assert expected_error in str(response_data), f"Expected error message: {expected_error}"
+    assert expected_error in str(
+        response_data
+    ), f"Expected error message: {expected_error}"
 
 
 @pytest.mark.asyncio
@@ -102,23 +128,37 @@ async def test_register_user_conflict(client, db_session, seed_user_groups):
     """
     payload = {
         "email": "conflictuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    response_first = await client.post("/api/v1/accounts/register/", json=payload)
-    assert response_first.status_code == 201, "Expected status code 201 for the first registration."
+    response_first = await client.post(
+        "/api/v1/accounts/register/", json=payload
+    )
+    assert (
+        response_first.status_code == 201
+    ), "Expected status code 201 for the first registration."
 
     stmt = select(UserModel).where(UserModel.email == payload["email"])
     result = await db_session.execute(stmt)
     created_user = result.scalars().first()
-    assert created_user is not None, "User should be created after the first registration."
+    assert (
+        created_user is not None
+    ), "User should be created after the first registration."
 
-    response_second = await client.post("/api/v1/accounts/register/", json=payload)
-    assert response_second.status_code == 409, "Expected status code 409 for a duplicate registration."
+    response_second = await client.post(
+        "/api/v1/accounts/register/", json=payload
+    )
+    assert (
+        response_second.status_code == 409
+    ), "Expected status code 409 for a duplicate registration."
 
     response_data = response_second.json()
-    expected_message = f"A user with this email {payload['email']} already exists."
-    assert response_data["detail"] == expected_message, f"Expected error message: {expected_message}"
+    expected_message = (
+        f"A user with this email {payload['email']} already exists."
+    )
+    assert (
+        response_data["detail"] == expected_message
+    ), f"Expected error message: {expected_message}"
 
 
 @pytest.mark.asyncio
@@ -134,17 +174,25 @@ async def test_register_user_internal_server_error(client, seed_user_groups):
     """
     payload = {
         "email": "erroruser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    with patch("routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError):
-        response = await client.post("/api/v1/accounts/register/", json=payload)
+    with patch(
+        "routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError
+    ):
+        response = await client.post(
+            "/api/v1/accounts/register/", json=payload
+        )
 
-        assert response.status_code == 500, "Expected status code 500 for internal server error."
+        assert (
+            response.status_code == 500
+        ), "Expected status code 500 for internal server error."
 
         response_data = response.json()
         expected_message = "An error occurred during user creation."
-        assert response_data["detail"] == expected_message, f"Expected error message: {expected_message}"
+        assert (
+            response_data["detail"] == expected_message
+        ), f"Expected error message: {expected_message}"
 
 
 @pytest.mark.asyncio
@@ -160,11 +208,15 @@ async def test_activate_account_success(client, db_session, seed_user_groups):
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
     stmt = (
         select(UserModel)
@@ -176,17 +228,26 @@ async def test_activate_account_success(client, db_session, seed_user_groups):
     assert user is not None, "User was not created in the database."
     assert not user.is_active, "Newly registered user should not be active."
 
-    assert user.activation_token is not None and user.activation_token.token is not None, \
-        "Activation token was not created in the database."
+    assert (
+        user.activation_token is not None
+        and user.activation_token.token is not None
+    ), "Activation token was not created in the database."
 
     activation_payload = {
         "email": registration_payload["email"],
-        "token": user.activation_token.token
+        "token": user.activation_token.token,
     }
 
-    activation_response = await client.post("/api/v1/accounts/activate/", json=activation_payload)
-    assert activation_response.status_code == 200, "Expected status code 200 for successful activation."
-    assert activation_response.json()["message"] == "User account activated successfully."
+    activation_response = await client.post(
+        "/api/v1/accounts/activate/", json=activation_payload
+    )
+    assert (
+        activation_response.status_code == 200
+    ), "Expected status code 200 for successful activation."
+    assert (
+        activation_response.json()["message"]
+        == "User account activated successfully."
+    )
 
     stmt = (
         select(UserModel)
@@ -198,14 +259,20 @@ async def test_activate_account_success(client, db_session, seed_user_groups):
     await db_session.refresh(user)
     assert user.is_active, "User should be active after successful activation."
 
-    stmt = select(ActivationTokenModel).where(ActivationTokenModel.user_id == user.id)
+    stmt = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == user.id
+    )
     result = await db_session.execute(stmt)
     token = result.scalars().first()
-    assert token is None, "Activation token should be deleted after successful activation."
+    assert (
+        token is None
+    ), "Activation token should be deleted after successful activation."
 
 
 @pytest.mark.asyncio
-async def test_activate_user_with_expired_token(client, db_session, seed_user_groups):
+async def test_activate_user_with_expired_token(
+    client, db_session, seed_user_groups
+):
     """
     Test activation with an expired token.
 
@@ -219,39 +286,58 @@ async def test_activate_user_with_expired_token(client, db_session, seed_user_gr
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
     assert not user.is_active, "User should not be active before activation."
 
-    stmt_token = select(ActivationTokenModel).where(ActivationTokenModel.user_id == user.id)
+    stmt_token = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     activation_token = result_token.scalars().first()
-    assert activation_token is not None, "Activation token should exist for the user."
+    assert (
+        activation_token is not None
+    ), "Activation token should exist for the user."
 
-    activation_token.expires_at = datetime.now(timezone.utc) - timedelta(days=2)
+    activation_token.expires_at = datetime.now(timezone.utc) - timedelta(
+        days=2
+    )
     await db_session.commit()
 
     activation_payload = {
         "email": registration_payload["email"],
-        "token": activation_token.token
+        "token": activation_token.token,
     }
-    activation_response = await client.post("/api/v1/accounts/activate/", json=activation_payload)
-
-    assert activation_response.status_code == 400, "Expected status code 400 for expired token."
-    assert activation_response.json()["detail"] == "Invalid or expired activation token.", (
-        "Expected error message for expired token."
+    activation_response = await client.post(
+        "/api/v1/accounts/activate/", json=activation_payload
     )
+
+    assert (
+        activation_response.status_code == 400
+    ), "Expected status code 400 for expired token."
+    assert (
+        activation_response.json()["detail"]
+        == "Invalid or expired activation token."
+    ), "Expected error message for expired token."
 
 
 @pytest.mark.asyncio
-async def test_activate_user_with_deleted_token(client, db_session, seed_user_groups):
+async def test_activate_user_with_deleted_token(
+    client, db_session, seed_user_groups
+):
     """
     Test activation with a deleted token.
 
@@ -266,42 +352,61 @@ async def test_activate_user_with_deleted_token(client, db_session, seed_user_gr
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
     assert not user.is_active, "User should not be active before activation."
 
-    stmt_token = select(ActivationTokenModel).where(ActivationTokenModel.user_id == user.id)
+    stmt_token = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     activation_token = result_token.scalars().first()
-    assert activation_token is not None, "Activation token should exist for the user."
+    assert (
+        activation_token is not None
+    ), "Activation token should exist for the user."
 
     token_value = activation_token.token
 
     await db_session.execute(
-        delete(ActivationTokenModel).where(ActivationTokenModel.id == activation_token.id)
+        delete(ActivationTokenModel).where(
+            ActivationTokenModel.id == activation_token.id
+        )
     )
     await db_session.commit()
 
     activation_payload = {
         "email": registration_payload["email"],
-        "token": token_value
+        "token": token_value,
     }
-    activation_response = await client.post("/api/v1/accounts/activate/", json=activation_payload)
-    assert activation_response.status_code == 400, "Expected status code 400 for deleted token."
-    assert activation_response.json()["detail"] == "Invalid or expired activation token.", (
-        "Expected error message for deleted token."
+    activation_response = await client.post(
+        "/api/v1/accounts/activate/", json=activation_payload
     )
+    assert (
+        activation_response.status_code == 400
+    ), "Expected status code 400 for deleted token."
+    assert (
+        activation_response.json()["detail"]
+        == "Invalid or expired activation token."
+    ), "Expected error message for deleted token."
 
 
 @pytest.mark.asyncio
-async def test_activate_already_active_user(client, db_session, seed_user_groups):
+async def test_activate_already_active_user(
+    client, db_session, seed_user_groups
+):
     """
     Test activation of an already active user.
 
@@ -314,13 +419,19 @@ async def test_activate_already_active_user(client, db_session, seed_user_groups
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
@@ -328,24 +439,35 @@ async def test_activate_already_active_user(client, db_session, seed_user_groups
     user.is_active = True
     await db_session.commit()
 
-    stmt_token = select(ActivationTokenModel).where(ActivationTokenModel.user_id == user.id)
+    stmt_token = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     activation_token = result_token.scalars().first()
-    assert activation_token is not None, "Activation token should exist for the user."
+    assert (
+        activation_token is not None
+    ), "Activation token should exist for the user."
 
     activation_payload = {
         "email": registration_payload["email"],
-        "token": activation_token.token
+        "token": activation_token.token,
     }
-    activation_response = await client.post("/api/v1/accounts/activate/", json=activation_payload)
-    assert activation_response.status_code == 400, "Expected status code 400 for already active user."
-    assert activation_response.json()["detail"] == "User account is already active.", (
-        "Expected error message for already active user."
+    activation_response = await client.post(
+        "/api/v1/accounts/activate/", json=activation_payload
     )
+    assert (
+        activation_response.status_code == 400
+    ), "Expected status code 400 for already active user."
+    assert (
+        activation_response.json()["detail"]
+        == "User account is already active."
+    ), "Expected error message for already active user."
 
 
 @pytest.mark.asyncio
-async def test_request_password_reset_token_success(client, db_session, seed_user_groups):
+async def test_request_password_reset_token_success(
+    client, db_session, seed_user_groups
+):
     """
     Test successful password reset token request.
 
@@ -361,12 +483,18 @@ async def test_request_password_reset_token_success(client, db_session, seed_use
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
@@ -375,25 +503,39 @@ async def test_request_password_reset_token_success(client, db_session, seed_use
     await db_session.commit()
 
     reset_payload = {"email": registration_payload["email"]}
-    reset_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_payload)
-    assert reset_response.status_code == 200, "Expected status code 200 for successful token request."
-    assert reset_response.json()["message"] == "If you are registered, you will receive an email with instructions.", \
-        "Expected success message for password reset token request."
+    reset_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_payload
+    )
+    assert (
+        reset_response.status_code == 200
+    ), "Expected status code 200 for successful token request."
+    assert (
+        reset_response.json()["message"]
+        == "If you are registered, you will receive an email with instructions."
+    ), "Expected success message for password reset token request."
 
-    stmt_token = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == user.id)
+    stmt_token = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     reset_token = result_token.scalars().first()
-    assert reset_token is not None, "Password reset token should be created for the user."
+    assert (
+        reset_token is not None
+    ), "Password reset token should be created for the user."
 
     expires_at = reset_token.expires_at
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
 
-    assert expires_at > datetime.now(timezone.utc), "Password reset token should have a future expiration date."
+    assert expires_at > datetime.now(
+        timezone.utc
+    ), "Password reset token should have a future expiration date."
 
 
 @pytest.mark.asyncio
-async def test_request_password_reset_token_nonexistent_user(client, db_session):
+async def test_request_password_reset_token_nonexistent_user(
+    client, db_session
+):
     """
     Test password reset token request for a non-existent user.
 
@@ -402,20 +544,29 @@ async def test_request_password_reset_token_nonexistent_user(client, db_session)
     """
     reset_payload = {"email": "nonexistent@example.com"}
 
-    reset_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_payload)
-    assert reset_response.status_code == 200, "Expected status code 200 for non-existent user request."
-    assert reset_response.json()["message"] == "If you are registered, you will receive an email with instructions.", (
-        "Expected generic success message for non-existent user request."
+    reset_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_payload
     )
+    assert (
+        reset_response.status_code == 200
+    ), "Expected status code 200 for non-existent user request."
+    assert (
+        reset_response.json()["message"]
+        == "If you are registered, you will receive an email with instructions."
+    ), "Expected generic success message for non-existent user request."
 
     stmt = select(func.count(PasswordResetTokenModel.id))
     result = await db_session.execute(stmt)
     reset_token_count = result.scalar_one()
-    assert reset_token_count == 0, "No password reset token should be created for non-existent user."
+    assert (
+        reset_token_count == 0
+    ), "No password reset token should be created for non-existent user."
 
 
 @pytest.mark.asyncio
-async def test_request_password_reset_token_for_inactive_user(client, db_session, seed_user_groups):
+async def test_request_password_reset_token_for_inactive_user(
+    client, db_session, seed_user_groups
+):
     """
     Test password reset token request for a registered but inactive user.
 
@@ -424,28 +575,43 @@ async def test_request_password_reset_token_for_inactive_user(client, db_session
     """
     registration_payload = {
         "email": "inactiveuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     created_user = result.scalars().first()
     assert created_user is not None, "User should be created in the database."
-    assert not created_user.is_active, "User should not be active after registration."
+    assert (
+        not created_user.is_active
+    ), "User should not be active after registration."
 
     reset_payload = {"email": registration_payload["email"]}
-    reset_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_payload)
-    assert reset_response.status_code == 200, "Expected status code 200 for inactive user password reset request."
-    assert reset_response.json()["message"] == "If you are registered, you will receive an email with instructions.", (
-        "Expected generic success message for inactive user password reset request."
+    reset_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_payload
     )
+    assert (
+        reset_response.status_code == 200
+    ), "Expected status code 200 for inactive user password reset request."
+    assert (
+        reset_response.json()["message"]
+        == "If you are registered, you will receive an email with instructions."
+    ), "Expected generic success message for inactive user password reset request."
 
     stmt_tokens = select(func.count(PasswordResetTokenModel.id))
     result_tokens = await db_session.execute(stmt_tokens)
     reset_token_count = result_tokens.scalar_one()
-    assert reset_token_count == 0, "No password reset token should be created for an inactive user."
+    assert (
+        reset_token_count == 0
+    ), "No password reset token should be created for an inactive user."
 
 
 @pytest.mark.asyncio
@@ -462,54 +628,84 @@ async def test_reset_password_success(client, db_session, seed_user_groups):
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "OldPassword123!"
+        "password": "OldPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "Expected status code 201 for successful registration."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "Expected status code 201 for successful registration."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     created_user = result.scalars().first()
     assert created_user is not None, "User should be created in the database."
 
-    stmt_token = select(ActivationTokenModel).where(ActivationTokenModel.user_id == created_user.id)
+    stmt_token = select(ActivationTokenModel).where(
+        ActivationTokenModel.user_id == created_user.id
+    )
     result_token = await db_session.execute(stmt_token)
     activation_token = result_token.scalars().first()
-    assert activation_token is not None, "Activation token should be created in the database."
+    assert (
+        activation_token is not None
+    ), "Activation token should be created in the database."
 
     activation_payload = {
         "email": registration_payload["email"],
-        "token": activation_token.token
+        "token": activation_token.token,
     }
-    activation_response = await client.post("/api/v1/accounts/activate/", json=activation_payload)
-    assert activation_response.status_code == 200, "Expected status code 200 for successful activation."
+    activation_response = await client.post(
+        "/api/v1/accounts/activate/", json=activation_payload
+    )
+    assert (
+        activation_response.status_code == 200
+    ), "Expected status code 200 for successful activation."
 
     await db_session.refresh(created_user)
-    assert created_user.is_active, "User should be active after successful activation."
+    assert (
+        created_user.is_active
+    ), "User should be active after successful activation."
 
     reset_request_payload = {"email": registration_payload["email"]}
-    reset_request_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_request_payload)
-    assert reset_request_response.status_code == 200, "Expected status code 200 for password reset token request."
+    reset_request_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_request_payload
+    )
+    assert (
+        reset_request_response.status_code == 200
+    ), "Expected status code 200 for password reset token request."
 
-    stmt_reset = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == created_user.id)
+    stmt_reset = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == created_user.id
+    )
     result_reset = await db_session.execute(stmt_reset)
     reset_token_record = result_reset.scalars().first()
-    assert reset_token_record is not None, "Password reset token should be created in the database."
+    assert (
+        reset_token_record is not None
+    ), "Password reset token should be created in the database."
 
     new_password = "NewSecurePassword123!"
     reset_payload = {
         "email": registration_payload["email"],
         "token": reset_token_record.token,
-        "password": new_password
+        "password": new_password,
     }
-    reset_response = await client.post("/api/v1/accounts/reset-password/complete/", json=reset_payload)
-    assert reset_response.status_code == 200, "Expected status code 200 for successful password reset."
-    assert reset_response.json()["message"] == "Password reset successfully.", (
-        "Unexpected response message for password reset."
+    reset_response = await client.post(
+        "/api/v1/accounts/reset-password/complete/", json=reset_payload
     )
+    assert (
+        reset_response.status_code == 200
+    ), "Expected status code 200 for successful password reset."
+    assert (
+        reset_response.json()["message"] == "Password reset successfully."
+    ), "Unexpected response message for password reset."
 
     await db_session.refresh(created_user)
-    assert created_user.verify_password(new_password), "Password should be updated successfully in the database."
+    assert created_user.verify_password(
+        new_password
+    ), "Password should be updated successfully in the database."
 
 
 @pytest.mark.asyncio
@@ -522,17 +718,25 @@ async def test_reset_password_invalid_email(client, db_session):
     reset_payload = {
         "email": "nonexistent@example.com",
         "token": "random_token",
-        "password": "NewSecurePassword123!"
+        "password": "NewSecurePassword123!",
     }
 
-    response = await client.post("/api/v1/accounts/reset-password/complete/", json=reset_payload)
+    response = await client.post(
+        "/api/v1/accounts/reset-password/complete/", json=reset_payload
+    )
 
-    assert response.status_code == 400, "Expected status code 400 for invalid email."
-    assert response.json()["detail"] == "Invalid email or token.", "Unexpected error message."
+    assert (
+        response.status_code == 400
+    ), "Expected status code 400 for invalid email."
+    assert (
+        response.json()["detail"] == "Invalid email or token."
+    ), "Unexpected error message."
 
 
 @pytest.mark.asyncio
-async def test_reset_password_invalid_token(client, db_session, seed_user_groups):
+async def test_reset_password_invalid_token(
+    client, db_session, seed_user_groups
+):
     """
     Test password reset with an incorrect token.
 
@@ -541,12 +745,16 @@ async def test_reset_password_invalid_token(client, db_session, seed_user_groups
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    response = await client.post("/api/v1/accounts/register/", json=registration_payload)
+    response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
     assert response.status_code == 201, "User registration failed."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
@@ -555,26 +763,39 @@ async def test_reset_password_invalid_token(client, db_session, seed_user_groups
     await db_session.commit()
 
     reset_request_payload = {"email": registration_payload["email"]}
-    response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_request_payload)
+    response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_request_payload
+    )
     assert response.status_code == 200, "Password reset request failed."
 
     reset_complete_payload = {
         "email": registration_payload["email"],
         "token": "incorrect_token",
-        "password": "NewSecurePassword123!"
+        "password": "NewSecurePassword123!",
     }
-    response = await client.post("/api/v1/accounts/reset-password/complete/", json=reset_complete_payload)
-    assert response.status_code == 400, "Expected status code 400 for invalid token."
-    assert response.json()["detail"] == "Invalid email or token.", "Unexpected error message."
+    response = await client.post(
+        "/api/v1/accounts/reset-password/complete/",
+        json=reset_complete_payload,
+    )
+    assert (
+        response.status_code == 400
+    ), "Expected status code 400 for invalid token."
+    assert (
+        response.json()["detail"] == "Invalid email or token."
+    ), "Unexpected error message."
 
-    stmt_token = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == user.id)
+    stmt_token = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     token_record = result_token.scalars().first()
     assert token_record is None, "Invalid token was not removed."
 
 
 @pytest.mark.asyncio
-async def test_reset_password_expired_token(client, db_session, seed_user_groups):
+async def test_reset_password_expired_token(
+    client, db_session, seed_user_groups
+):
     """
     Test password reset with an expired token.
 
@@ -583,12 +804,18 @@ async def test_reset_password_expired_token(client, db_session, seed_user_groups
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "User registration failed."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "User registration failed."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
@@ -597,10 +824,16 @@ async def test_reset_password_expired_token(client, db_session, seed_user_groups
     await db_session.commit()
 
     reset_request_payload = {"email": registration_payload["email"]}
-    reset_request_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_request_payload)
-    assert reset_request_response.status_code == 200, "Password reset request failed."
+    reset_request_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_request_payload
+    )
+    assert (
+        reset_request_response.status_code == 200
+    ), "Password reset request failed."
 
-    stmt_token = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == user.id)
+    stmt_token = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     token_record = result_token.scalars().first()
     assert token_record is not None, "Password reset token not created."
@@ -611,20 +844,31 @@ async def test_reset_password_expired_token(client, db_session, seed_user_groups
     reset_complete_payload = {
         "email": registration_payload["email"],
         "token": token_record.token,
-        "password": "NewSecurePassword123!"
+        "password": "NewSecurePassword123!",
     }
-    reset_response = await client.post("/api/v1/accounts/reset-password/complete/", json=reset_complete_payload)
-    assert reset_response.status_code == 400, "Expected status code 400 for expired token."
-    assert reset_response.json()["detail"] == "Invalid email or token.", "Unexpected error message."
+    reset_response = await client.post(
+        "/api/v1/accounts/reset-password/complete/",
+        json=reset_complete_payload,
+    )
+    assert (
+        reset_response.status_code == 400
+    ), "Expected status code 400 for expired token."
+    assert (
+        reset_response.json()["detail"] == "Invalid email or token."
+    ), "Unexpected error message."
 
-    stmt_token_check = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == user.id)
+    stmt_token_check = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == user.id
+    )
     result_token_check = await db_session.execute(stmt_token_check)
     expired_token = result_token_check.scalars().first()
     assert expired_token is None, "Expired token was not removed."
 
 
 @pytest.mark.asyncio
-async def test_reset_password_sqlalchemy_error(client, db_session, seed_user_groups):
+async def test_reset_password_sqlalchemy_error(
+    client, db_session, seed_user_groups
+):
     """
     Test password reset when a database commit raises SQLAlchemyError.
 
@@ -640,12 +884,18 @@ async def test_reset_password_sqlalchemy_error(client, db_session, seed_user_gro
     """
     registration_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    registration_response = await client.post("/api/v1/accounts/register/", json=registration_payload)
-    assert registration_response.status_code == 201, "User registration failed."
+    registration_response = await client.post(
+        "/api/v1/accounts/register/", json=registration_payload
+    )
+    assert (
+        registration_response.status_code == 201
+    ), "User registration failed."
 
-    stmt = select(UserModel).where(UserModel.email == registration_payload["email"])
+    stmt = select(UserModel).where(
+        UserModel.email == registration_payload["email"]
+    )
     result = await db_session.execute(stmt)
     user = result.scalars().first()
     assert user is not None, "User should exist in the database."
@@ -654,10 +904,16 @@ async def test_reset_password_sqlalchemy_error(client, db_session, seed_user_gro
     await db_session.commit()
 
     reset_request_payload = {"email": registration_payload["email"]}
-    reset_request_response = await client.post("/api/v1/accounts/password-reset/request/", json=reset_request_payload)
-    assert reset_request_response.status_code == 200, "Password reset request failed."
+    reset_request_response = await client.post(
+        "/api/v1/accounts/password-reset/request/", json=reset_request_payload
+    )
+    assert (
+        reset_request_response.status_code == 200
+    ), "Password reset request failed."
 
-    stmt_token = select(PasswordResetTokenModel).where(PasswordResetTokenModel.user_id == user.id)
+    stmt_token = select(PasswordResetTokenModel).where(
+        PasswordResetTokenModel.user_id == user.id
+    )
     result_token = await db_session.execute(stmt_token)
     token_record = result_token.scalars().first()
     assert token_record is not None, "Password reset token not created."
@@ -665,20 +921,30 @@ async def test_reset_password_sqlalchemy_error(client, db_session, seed_user_gro
     reset_complete_payload = {
         "email": registration_payload["email"],
         "token": token_record.token,
-        "password": "NewSecurePassword123!"
+        "password": "NewSecurePassword123!",
     }
 
-    with patch("routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError):
-        reset_response = await client.post("/api/v1/accounts/reset-password/complete/", json=reset_complete_payload)
+    with patch(
+        "routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError
+    ):
+        reset_response = await client.post(
+            "/api/v1/accounts/reset-password/complete/",
+            json=reset_complete_payload,
+        )
 
-    assert reset_response.status_code == 500, "Expected status code 500 for SQLAlchemyError."
-    assert reset_response.json()["detail"] == "An error occurred while resetting the password.", (
-        "Unexpected error message for SQLAlchemyError."
-    )
+    assert (
+        reset_response.status_code == 500
+    ), "Expected status code 500 for SQLAlchemyError."
+    assert (
+        reset_response.json()["detail"]
+        == "An error occurred while resetting the password."
+    ), "Unexpected error message for SQLAlchemyError."
 
 
 @pytest.mark.asyncio
-async def test_login_user_success(client, db_session, jwt_manager, seed_user_groups):
+async def test_login_user_success(
+    client, db_session, jwt_manager, seed_user_groups
+):
     """
     Test successful login.
 
@@ -687,10 +953,12 @@ async def test_login_user_success(client, db_session, jwt_manager, seed_user_gro
     """
     user_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "Default user group should exist."
@@ -698,7 +966,7 @@ async def test_login_user_success(client, db_session, jwt_manager, seed_user_gro
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = True
     db_session.add(user)
@@ -706,33 +974,55 @@ async def test_login_user_success(client, db_session, jwt_manager, seed_user_gro
 
     login_payload = {
         "email": user_payload["email"],
-        "password": user_payload["password"]
+        "password": user_payload["password"],
     }
     response = await client.post("/api/v1/accounts/login/", json=login_payload)
-    assert response.status_code == 201, "Expected status code 201 for successful login."
+    assert (
+        response.status_code == 201
+    ), "Expected status code 201 for successful login."
     response_data = response.json()
-    assert "access_token" in response_data, "Access token is missing in the response."
-    assert "refresh_token" in response_data, "Refresh token is missing in the response."
+    assert (
+        "access_token" in response_data
+    ), "Access token is missing in the response."
+    assert (
+        "refresh_token" in response_data
+    ), "Refresh token is missing in the response."
     assert response_data["access_token"], "Access token is empty."
     assert response_data["refresh_token"], "Refresh token is empty."
 
-    access_token_data = jwt_manager.decode_access_token(response_data["access_token"])
-    assert access_token_data["user_id"] == user.id, "Access token does not contain correct user ID."
+    access_token_data = jwt_manager.decode_access_token(
+        response_data["access_token"]
+    )
+    assert (
+        access_token_data["user_id"] == user.id
+    ), "Access token does not contain correct user ID."
 
-    refresh_token_data = jwt_manager.decode_refresh_token(response_data["refresh_token"])
-    assert refresh_token_data["user_id"] == user.id, "Refresh token does not contain correct user ID."
+    refresh_token_data = jwt_manager.decode_refresh_token(
+        response_data["refresh_token"]
+    )
+    assert (
+        refresh_token_data["user_id"] == user.id
+    ), "Refresh token does not contain correct user ID."
 
-    stmt_refresh = select(RefreshTokenModel).where(RefreshTokenModel.user_id == user.id)
+    stmt_refresh = select(RefreshTokenModel).where(
+        RefreshTokenModel.user_id == user.id
+    )
     result_refresh = await db_session.execute(stmt_refresh)
     refresh_token_record = result_refresh.scalars().first()
-    assert refresh_token_record is not None, "Refresh token was not stored in the database."
-    assert refresh_token_record.token == response_data["refresh_token"], "Stored refresh token does not match."
+    assert (
+        refresh_token_record is not None
+    ), "Refresh token was not stored in the database."
+    assert (
+        refresh_token_record.token == response_data["refresh_token"]
+    ), "Stored refresh token does not match."
 
     expires_at = refresh_token_record.expires_at
     if expires_at.tzinfo is None:
         expires_at = expires_at.replace(tzinfo=timezone.utc)
 
-    assert expires_at > datetime.now(timezone.utc), "Refresh token is already expired."
+    assert expires_at > datetime.now(
+        timezone.utc
+    ), "Refresh token is already expired."
 
 
 @pytest.mark.asyncio
@@ -744,18 +1034,23 @@ async def test_login_user_invalid_cases(client, db_session, seed_user_groups):
     """
     login_payload = {
         "email": "nonexistent@example.com",
-        "password": "SomePassword123!"
+        "password": "SomePassword123!",
     }
     response = await client.post("/api/v1/accounts/login/", json=login_payload)
-    assert response.status_code == 401, "Expected status code 401 for non-existent user."
-    assert response.json()["detail"] == "Invalid email or password.", \
-        "Unexpected error message for non-existent user."
+    assert (
+        response.status_code == 401
+    ), "Expected status code 401 for non-existent user."
+    assert (
+        response.json()["detail"] == "Invalid email or password."
+    ), "Unexpected error message for non-existent user."
 
     user_payload = {
         "email": "testuser@example.com",
-        "password": "CorrectPassword123!"
+        "password": "CorrectPassword123!",
     }
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "Default user group should exist."
@@ -763,7 +1058,7 @@ async def test_login_user_invalid_cases(client, db_session, seed_user_groups):
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = True
     db_session.add(user)
@@ -771,16 +1066,23 @@ async def test_login_user_invalid_cases(client, db_session, seed_user_groups):
 
     login_payload_incorrect_password = {
         "email": user_payload["email"],
-        "password": "WrongPassword123!"
+        "password": "WrongPassword123!",
     }
-    response = await client.post("/api/v1/accounts/login/", json=login_payload_incorrect_password)
-    assert response.status_code == 401, "Expected status code 401 for incorrect password."
-    assert response.json()["detail"] == "Invalid email or password.", \
-        "Unexpected error message for incorrect password."
+    response = await client.post(
+        "/api/v1/accounts/login/", json=login_payload_incorrect_password
+    )
+    assert (
+        response.status_code == 401
+    ), "Expected status code 401 for incorrect password."
+    assert (
+        response.json()["detail"] == "Invalid email or password."
+    ), "Unexpected error message for incorrect password."
 
 
 @pytest.mark.asyncio
-async def test_login_user_inactive_account(client, db_session, seed_user_groups):
+async def test_login_user_inactive_account(
+    client, db_session, seed_user_groups
+):
     """
     Test login with an inactive user account.
 
@@ -789,10 +1091,12 @@ async def test_login_user_inactive_account(client, db_session, seed_user_groups)
     """
     user_payload = {
         "email": "inactiveuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "User group not found."
@@ -800,7 +1104,7 @@ async def test_login_user_inactive_account(client, db_session, seed_user_groups)
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = False
     db_session.add(user)
@@ -808,13 +1112,16 @@ async def test_login_user_inactive_account(client, db_session, seed_user_groups)
 
     login_payload = {
         "email": user_payload["email"],
-        "password": user_payload["password"]
+        "password": user_payload["password"],
     }
     response = await client.post("/api/v1/accounts/login/", json=login_payload)
 
-    assert response.status_code == 403, "Expected status code 403 for inactive user."
-    assert response.json()["detail"] == "User account is not activated.", \
-        "Unexpected error message for inactive user."
+    assert (
+        response.status_code == 403
+    ), "Expected status code 403 for inactive user."
+    assert (
+        response.json()["detail"] == "User account is not activated."
+    ), "Unexpected error message for inactive user."
 
 
 @pytest.mark.asyncio
@@ -826,9 +1133,11 @@ async def test_login_user_commit_error(client, db_session, seed_user_groups):
     """
     user_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "Default user group should exist."
@@ -836,7 +1145,7 @@ async def test_login_user_commit_error(client, db_session, seed_user_groups):
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = True
     db_session.add(user)
@@ -844,20 +1153,29 @@ async def test_login_user_commit_error(client, db_session, seed_user_groups):
 
     login_payload = {
         "email": user_payload["email"],
-        "password": user_payload["password"]
+        "password": user_payload["password"],
     }
 
-    with patch("routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError):
-        response = await client.post("/api/v1/accounts/login/", json=login_payload)
+    with patch(
+        "routes.accounts.AsyncSession.commit", side_effect=SQLAlchemyError
+    ):
+        response = await client.post(
+            "/api/v1/accounts/login/", json=login_payload
+        )
 
-    assert response.status_code == 500, "Expected status code 500 for database commit error."
-    assert response.json()["detail"] == "An error occurred while processing the request.", (
-        "Unexpected error message for database commit error."
-    )
+    assert (
+        response.status_code == 500
+    ), "Expected status code 500 for database commit error."
+    assert (
+        response.json()["detail"]
+        == "An error occurred while processing the request."
+    ), "Unexpected error message for database commit error."
 
 
 @pytest.mark.asyncio
-async def test_refresh_access_token_success(client, db_session, jwt_manager, seed_user_groups):
+async def test_refresh_access_token_success(
+    client, db_session, jwt_manager, seed_user_groups
+):
     """
     Test successful access token refresh.
 
@@ -870,9 +1188,11 @@ async def test_refresh_access_token_success(client, db_session, jwt_manager, see
     """
     user_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "Default user group should exist."
@@ -880,7 +1200,7 @@ async def test_refresh_access_token_success(client, db_session, jwt_manager, see
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = True
     db_session.add(user)
@@ -888,22 +1208,36 @@ async def test_refresh_access_token_success(client, db_session, jwt_manager, see
 
     login_payload = {
         "email": user_payload["email"],
-        "password": user_payload["password"]
+        "password": user_payload["password"],
     }
-    login_response = await client.post("/api/v1/accounts/login/", json=login_payload)
-    assert login_response.status_code == 201, "Expected status code 201 for successful login."
+    login_response = await client.post(
+        "/api/v1/accounts/login/", json=login_payload
+    )
+    assert (
+        login_response.status_code == 201
+    ), "Expected status code 201 for successful login."
     login_data = login_response.json()
     refresh_token = login_data["refresh_token"]
 
     refresh_payload = {"refresh_token": refresh_token}
-    refresh_response = await client.post("/api/v1/accounts/refresh/", json=refresh_payload)
-    assert refresh_response.status_code == 200, "Expected status code 200 for successful token refresh."
+    refresh_response = await client.post(
+        "/api/v1/accounts/refresh/", json=refresh_payload
+    )
+    assert (
+        refresh_response.status_code == 200
+    ), "Expected status code 200 for successful token refresh."
     refresh_data = refresh_response.json()
-    assert "access_token" in refresh_data, "Access token is missing in the response."
+    assert (
+        "access_token" in refresh_data
+    ), "Access token is missing in the response."
     assert refresh_data["access_token"], "Access token is empty."
 
-    access_token_data = jwt_manager.decode_access_token(refresh_data["access_token"])
-    assert access_token_data["user_id"] == user.id, "Access token does not contain correct user ID."
+    access_token_data = jwt_manager.decode_access_token(
+        refresh_data["access_token"]
+    )
+    assert (
+        access_token_data["user_id"] == user.id
+    ), "Access token does not contain correct user ID."
 
 
 @pytest.mark.asyncio
@@ -915,15 +1249,20 @@ async def test_refresh_access_token_expired_token(client, jwt_manager):
     when the refresh token is expired.
     """
     expired_token = jwt_manager.create_refresh_token(
-        {"user_id": 1},
-        expires_delta=timedelta(days=-1)
+        {"user_id": 1}, expires_delta=timedelta(days=-1)
     )
 
     refresh_payload = {"refresh_token": expired_token}
-    refresh_response = await client.post("/api/v1/accounts/refresh/", json=refresh_payload)
+    refresh_response = await client.post(
+        "/api/v1/accounts/refresh/", json=refresh_payload
+    )
 
-    assert refresh_response.status_code == 400, "Expected status code 400 for expired token."
-    assert refresh_response.json()["detail"] == "Token has expired.", "Unexpected error message."
+    assert (
+        refresh_response.status_code == 400
+    ), "Expected status code 400 for expired token."
+    assert (
+        refresh_response.json()["detail"] == "Token has expired."
+    ), "Unexpected error message."
 
 
 @pytest.mark.asyncio
@@ -936,14 +1275,22 @@ async def test_refresh_access_token_token_not_found(client, jwt_manager):
     """
     refresh_token = jwt_manager.create_refresh_token({"user_id": 1})
     refresh_payload = {"refresh_token": refresh_token}
-    refresh_response = await client.post("/api/v1/accounts/refresh/", json=refresh_payload)
+    refresh_response = await client.post(
+        "/api/v1/accounts/refresh/", json=refresh_payload
+    )
 
-    assert refresh_response.status_code == 401, "Expected status code 401 for token not found."
-    assert refresh_response.json()["detail"] == "Refresh token not found.", "Unexpected error message."
+    assert (
+        refresh_response.status_code == 401
+    ), "Expected status code 401 for token not found."
+    assert (
+        refresh_response.json()["detail"] == "Refresh token not found."
+    ), "Unexpected error message."
 
 
 @pytest.mark.asyncio
-async def test_refresh_access_token_user_not_found(client, db_session, jwt_manager, seed_user_groups):
+async def test_refresh_access_token_user_not_found(
+    client, db_session, jwt_manager, seed_user_groups
+):
     """
     Test refresh token when user ID inside the token does not exist in the database.
 
@@ -959,10 +1306,12 @@ async def test_refresh_access_token_user_not_found(client, db_session, jwt_manag
     """
     user_payload = {
         "email": "testuser@example.com",
-        "password": "StrongPassword123!"
+        "password": "StrongPassword123!",
     }
 
-    stmt = select(UserGroupModel).where(UserGroupModel.name == UserGroupEnum.USER)
+    stmt = select(UserGroupModel).where(
+        UserGroupModel.name == UserGroupEnum.USER
+    )
     result = await db_session.execute(stmt)
     user_group = result.scalars().first()
     assert user_group is not None, "Default user group should exist."
@@ -970,25 +1319,234 @@ async def test_refresh_access_token_user_not_found(client, db_session, jwt_manag
     user = UserModel.create(
         email=user_payload["email"],
         raw_password=user_payload["password"],
-        group_id=user_group.id
+        group_id=user_group.id,
     )
     user.is_active = True
     db_session.add(user)
     await db_session.commit()
 
     invalid_user_id = 9999
-    refresh_token = jwt_manager.create_refresh_token({"user_id": invalid_user_id})
+    refresh_token = jwt_manager.create_refresh_token(
+        {"user_id": invalid_user_id}
+    )
 
     refresh_token_record = RefreshTokenModel.create(
-        user_id=invalid_user_id,
-        days_valid=7,
-        token=refresh_token
+        user_id=invalid_user_id, days_valid=7, token=refresh_token
     )
     db_session.add(refresh_token_record)
     await db_session.commit()
 
     refresh_payload = {"refresh_token": refresh_token}
-    refresh_response = await client.post("/api/v1/accounts/refresh/", json=refresh_payload)
+    refresh_response = await client.post(
+        "/api/v1/accounts/refresh/", json=refresh_payload
+    )
 
-    assert refresh_response.status_code == 404, "Expected status code 404 for non-existent user."
-    assert refresh_response.json()["detail"] == "User not found.", "Unexpected error message."
+    assert (
+        refresh_response.status_code == 404
+    ), "Expected status code 404 for non-existent user."
+    assert (
+        refresh_response.json()["detail"] == "User not found."
+    ), "Unexpected error message."
+
+
+@pytest.mark.asyncio
+async def test_regenerate_activation_link_user_not_found(
+    client, db_session, seed_user_groups
+):
+    """
+    Should return 404 if user does not exist.
+    """
+    payload = {"email": "notfound@example.com"}
+    response = await client.post(
+        "/api/v1/accounts/regenerate-activation-link/", json=payload
+    )
+    assert response.status_code == 404
+    assert (
+        response.json()["detail"] == "User with such email is not registered."
+    )
+
+
+@pytest.mark.asyncio
+async def test_regenerate_activation_link_user_active(
+    client, db_session, seed_user_groups
+):
+    """
+    Should return 400 if user is already active.
+    """
+    # Register and activate user
+    payload = {
+        "email": "activeuser@example.com",
+        "password": "StrongPassword123!",
+    }
+    await client.post("/api/v1/accounts/register/", json=payload)
+    user = (
+        (
+            await db_session.execute(
+                select(UserModel).where(UserModel.email == payload["email"])
+            )
+        )
+        .scalars()
+        .first()
+    )
+    user.is_active = True
+    await db_session.commit()
+    response = await client.post(
+        "/api/v1/accounts/regenerate-activation-link/",
+        json={"email": payload["email"]},
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "User already active."
+
+
+@pytest.mark.asyncio
+async def test_regenerate_activation_link_already_has_valid_token(
+    client, db_session, seed_user_groups
+):
+    """
+    Should return 409 if user already has a valid activation token.
+    """
+    payload = {
+        "email": "validtoken@example.com",
+        "password": "StrongPassword123!",
+    }
+    await client.post("/api/v1/accounts/register/", json=payload)
+    user = (
+        (
+            await db_session.execute(
+                select(UserModel).where(UserModel.email == payload["email"])
+            )
+        )
+        .scalars()
+        .first()
+    )
+    response = await client.post(
+        "/api/v1/accounts/regenerate-activation-link/",
+        json={"email": payload["email"]},
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"] == "User already have an activation link."
+
+
+@pytest.mark.asyncio
+async def test_regenerate_activation_link_expired_token(
+    client, db_session, seed_user_groups, seed_user
+):
+    """
+    Should delete expired token, create new one, and return success message.
+    """
+    payload = {
+        "email": "expiredtoken@example.com",
+        "password": "StrongPassword123!",
+    }
+    await client.post("/api/v1/accounts/register/", json=payload)
+    user = (
+        (
+            await db_session.execute(
+                select(UserModel).where(UserModel.email == payload["email"])
+            )
+        )
+        .scalars()
+        .first()
+    )
+    token = (
+        (
+            await db_session.execute(
+                select(ActivationTokenModel).where(
+                    ActivationTokenModel.user_id == user.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    token.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
+    await db_session.commit()
+
+    other_user_activation_token = ActivationTokenModel(user_id=seed_user.id)
+    db_session.add(other_user_activation_token)
+
+    await db_session.commit()
+    response = await client.post(
+        "/api/v1/accounts/regenerate-activation-link/",
+        json={"email": payload["email"]},
+    )
+    assert response.status_code == 200
+    assert (
+        "you will receive an email with activation link"
+        in response.json()["message"]
+    )
+    # Should have a new token
+    new_token = (
+        (
+            await db_session.execute(
+                select(ActivationTokenModel).where(
+                    ActivationTokenModel.user_id == user.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert new_token is not None
+    assert new_token.id != token.id
+
+
+@pytest.mark.asyncio
+async def test_regenerate_activation_link_no_token(
+    client, db_session, seed_user_groups
+):
+    """
+    Should create a new activation token if none exists.
+    """
+    payload = {
+        "email": "notoken@example.com",
+        "password": "StrongPassword123!",
+    }
+    await client.post("/api/v1/accounts/register/", json=payload)
+    user = (
+        (
+            await db_session.execute(
+                select(UserModel).where(UserModel.email == payload["email"])
+            )
+        )
+        .scalars()
+        .first()
+    )
+    # Remove token
+    token = (
+        (
+            await db_session.execute(
+                select(ActivationTokenModel).where(
+                    ActivationTokenModel.user_id == user.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    await db_session.execute(
+        delete(ActivationTokenModel).where(ActivationTokenModel.id == token.id)
+    )
+    await db_session.commit()
+    response = await client.post(
+        "/api/v1/accounts/regenerate-activation-link/",
+        json={"email": payload["email"]},
+    )
+    assert response.status_code == 200
+    assert (
+        "you will receive an email with activation link"
+        in response.json()["message"]
+    )
+    # Should have a new token
+    new_token = (
+        (
+            await db_session.execute(
+                select(ActivationTokenModel).where(
+                    ActivationTokenModel.user_id == user.id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    assert new_token is not None


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint allowing users to request regeneration of their account activation link via email.

- **Bug Fixes**
  - Improved documentation for possible errors in the password reset request endpoint.

- **Tests**
  - Introduced comprehensive tests for the activation link regeneration feature, covering various user and token states.
  - Added a new fixture to simplify user seeding in tests.

- **Style**
  - Reformatted test code and schema definitions for better readability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->